### PR TITLE
Update Package.swift to include macOS platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let package = Package(
   name: "GoogleAppMeasurement",
-  platforms: [.iOS(.v10)],
+  platforms: [.iOS(.v10), .macOS(.v10_12)],
   products: [
     .library(
       name: "GoogleAppMeasurement",


### PR DESCRIPTION
Pulling this library in using a macOS target results in a package resolution error. This ensures the macOS version is specified in the package manifest.

```
error: the library 'GoogleAppMeasurementWithoutAdIdSupportTarget' requires macos 10.10, but depends on the product 'GULAppDelegateSwizzler' which requires macos 10.12; consider changing the library 'GoogleAppMeasurementWithoutAdIdSupportTarget' to require macos 10.12 or later, or the product 'GULAppDelegateSwizzler' to require macos 10.10 or earlier.
```