### PR TITLE
Update nanopb version in advance of Firebase 9.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/firebase/nanopb.git",
-      "2.30908.0" ..< "2.30909.0"
+      "2.30908.0" ..< "2.30910.0"
     ),
   ],
   targets: [


### PR DESCRIPTION
Support both old and new version since they're compatible and to ease the transition.

See also https://github.com/google/nanopb-podspec/pull/19 and https://github.com/firebase/firebase-ios-sdk/pull/9765