### PR TITLE
Xcode fails to build package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2021 Google LLC
 //


### PR DESCRIPTION
Have to remove the line below (line 2) from Package.swift. This solves the error during package resolving
// The swift-tools-version declares the minimum version of Swift required to build this package.