### PR TITLE
[watchOS] Workaround for watchOS SwiftUI Previews build issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let package = Package(
   name: "GoogleAppMeasurement",
-  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v12)],
+  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v12), .watchOS(.v6)],
   products: [
     .library(
       name: "GoogleAppMeasurement",
@@ -50,8 +50,14 @@ let package = Package(
     .target(
       name: "GoogleAppMeasurementTarget",
       dependencies: [
-        "GoogleAppMeasurementIdentitySupport",
-        "GoogleAppMeasurement",
+        .target(
+          name: "GoogleAppMeasurementIdentitySupport",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
+        .target(
+          name: "GoogleAppMeasurement",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
         .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULNSData", package: "GoogleUtilities"),

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,10 @@ let package = Package(
     .target(
       name: "GoogleAppMeasurementWithoutAdIdSupportTarget",
       dependencies: [
-        "GoogleAppMeasurement",
+        .target(
+          name: "GoogleAppMeasurement",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
         .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULNSData", package: "GoogleUtilities"),
@@ -93,7 +96,10 @@ let package = Package(
     .target(
       name: "GoogleAppMeasurementOnDeviceConversionTarget",
       dependencies: [
-        "GoogleAppMeasurementOnDeviceConversion",
+        .target(
+          name: "GoogleAppMeasurementOnDeviceConversion",
+          condition: .when(platforms: [.iOS])
+        ),
       ],
       path: "GoogleAppMeasurementOnDeviceConversionWrapper",
       linkerSettings: [


### PR DESCRIPTION
### Context
For watchOS apps with a companion iOS app, building the watchOS scheme for SwiftUI previews will build the dependencies for the companion iOS app. This is problematic for cases when the companion iOS app includes dependencies that do not build on watchOS app.  It seems to affect Xcode 14.3+, and is still an issue on the latest Xcode 15 beta. The issue is discussed on the Apple Developer Forums ([thread](https://developer.apple.com/forums/thread/731732)) and a feedback ticket was reported to have been filed.

A workaround for the issue in #48 is to explicitly prevent GoogleAppMeasurement package from _trying_ to build for watchOS.

The current state of the error today complains `GoogleAppMeasurement` has dependencies with a higher minimum supported watchOS version. This is because GoogleAppMeasurement's Package.swift defaults to supporting watchOS 4.0. To change this, this PR add watchOS 6 as the minimum supported watchOS version for GoogleAppMeasurement. This resolves the related errors.

![image](https://github.com/google/GoogleAppMeasurement/assets/36927374/0f9245d5-57ae-48b8-8a79-fdc81a252df6)

The remaining errors are the "While building for watchOS simulator, no library for this platform was found..." ones, these can be resolved by conditionally including libraries only when the target platform supports them.

This worked in a test watchOS app + companion app using local packages.

Fix #48