### PR TITLE
fix: Explicitly depend on GoogleUilities targets used by GoogleAppMeasurement (firebase-ios-sdk/15276)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,8 @@ let package = Package(
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULNSData", package: "GoogleUtilities"),
         .product(name: "GULNetwork", package: "GoogleUtilities"),
+        .product(name: "GULLogger", package: "GoogleUtilities"),
+        .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "nanopb", package: "nanopb"),
         .product(
           name: "GoogleAdsOnDeviceConversion", package: "google-ads-on-device-conversion-ios-sdk"
@@ -83,6 +85,8 @@ let package = Package(
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULNSData", package: "GoogleUtilities"),
         .product(name: "GULNetwork", package: "GoogleUtilities"),
+        .product(name: "GULLogger", package: "GoogleUtilities"),
+        .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "nanopb", package: "nanopb"),
       ],
       path: "GoogleAppMeasurementCoreWrapper",
@@ -108,6 +112,8 @@ let package = Package(
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULNSData", package: "GoogleUtilities"),
         .product(name: "GULNetwork", package: "GoogleUtilities"),
+        .product(name: "GULLogger", package: "GoogleUtilities"),
+        .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "nanopb", package: "nanopb"),
       ],
       path: "GoogleAppMeasurementIdentitySupportWrapper",


### PR DESCRIPTION
Should address the following errors from https://github.com/firebase/firebase-ios-sdk/issues/15276

```
Undefined symbols for architecture arm64:
 "_GULIsLoggableLevel", referenced from:
-[APMMonitor isLoggableLevel:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
"_GULOSLogBasic", referenced from:
-[APMASLLogger logMessage:logTag:messageCode:withLogLevel:] in GoogleAppMeasurement[arm64][12](APMASLLogger.o)
 "_GULOSLogError", referenced from:
-[APMPersistentDictionary initWithFileName:] in GoogleAppMeasurement[arm64][287](APMPersistentDictionary.o)
_APMWriteDictionaryToURL in GoogleAppMeasurement[arm64][287](APMPersistentDictionary.o)
-[APMUserDefaults synchronize] in GoogleAppMeasurement[arm64][342](APMUserDefaults.o)
"_GULOSLogInfo", referenced from:
___44+[UIViewController(APMScreenClassName) load]_block_invoke in GoogleAppMeasurement[arm64][361](UIViewController+APMScreenClassName.o)
"_GULOSLogWarning", referenced from:
+[APMMeasurement sharedInstance] in GoogleAppMeasurement[arm64][62](APMMeasurement.o)
-[APMPersistentDictionary objectForKey:] in GoogleAppMeasurement[arm64][287](APMPersistentDictionary.o)
-[APMPersistentDictionary setObject:forKey:] in GoogleAppMeasurement[arm64][287](APMPersistentDictionary.o)
-[APMUserDefaults objectForKey:] in GoogleAppMeasurement[arm64][342](APMUserDefaults.o)
-[APMUserDefaults setObject:forKey:] in GoogleAppMeasurement[arm64][342](APMUserDefaults.o)
-[APMUserDefaults synchronize] in GoogleAppMeasurement[arm64][342](APMUserDefaults.o)
___44+[UIViewController(APMScreenClassName) load]_block_invoke in GoogleAppMeasurement[arm64][361](UIViewController+APMScreenClassName.o)
...
"_GULSetLoggerLevel", referenced from:
-[APMMonitor setDebugModeEnabled:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
 -[APMMonitor setDebugModeEnabled:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
-[APMMonitor setSGTMDebugModeEnabled:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
-[APMMonitor setSGTMDebugModeEnabled:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
-[APMMonitor setVerboseLoggingEnabled:] in GoogleAppMeasurement[arm64][70](APMMonitor.o)
"_OBJC_CLASS_$_GULAppEnvironmentUtil", referenced from:
  in GoogleAppMeasurement[arm64][5](APMAEU.o)
ld: symbol(s) not found for architecture arm64
```