### PR TITLE
Remove stale SPM workflow scheme

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -10,7 +10,7 @@ jobs:
   swift-build-run:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Verify iOS build
@@ -19,5 +19,3 @@ jobs:
       run:  xcodebuild -sdk 'appletvsimulator' -destination 'platform=tvOS Simulator,name=Apple TV' -scheme GoogleAppMeasurement
     - name: Verify macOS build
       run:  xcodebuild -sdk 'macosx' -destination 'platform=macOS' -scheme GoogleAppMeasurement
-    - name: Verify GoogleAppMeasurementOnDeviceConversion iOS build
-      run:  xcodebuild -sdk 'iphonesimulator' -destination 'platform=iOS Simulator,name=iPhone 11' -scheme GoogleAppMeasurementOnDeviceConversion


### PR DESCRIPTION
## Summary
- update the SPM workflow to use actions/checkout@v4
- remove the GoogleAppMeasurementOnDeviceConversion build step because that scheme is not defined by Package.swift

## Validation
- verified Package.swift only defines GoogleAppMeasurement, GoogleAppMeasurementCore, and GoogleAppMeasurementIdentitySupport products
- verified no remaining references to GoogleAppMeasurementOnDeviceConversion or actions/checkout@v2