### PR TITLE
chore: pin actions/checkout version in spm.yml

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -10,7 +10,7 @@ jobs:
   swift-build-run:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Verify iOS build


### PR DESCRIPTION
This is to pin the version of the 3p CI tool. We do the firebase repo and happened to notice we didn't have it done here.